### PR TITLE
Clean up .gitignore duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,3 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
-=======
-node_modules/
-dist/
-.env


### PR DESCRIPTION
## Summary
- remove stray merge markers in `.gitignore`
- deduplicate end-of-file entries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402353e1bc832e97eb49e1e4c97a1b