### PR TITLE
Add JWT_SECRET env example and check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+JWT_SECRET=your-secret

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ npm list express
 npm list cors
 ```
 
-### 3. Starta backend-servern
+### 3. Skapa en `.env`-fil
+Kopiera `.env.example` och döp den till `.env`. Sätt ett eget värde för `JWT_SECRET`.
+
+### 4. Starta backend-servern
 ```bash
 node server.js
 ```
@@ -46,13 +49,13 @@ node server.js
 
 ---
 
-### 4. Installera frontend-beroenden
+### 5. Installera frontend-beroenden
 ```bash
 cd ../frontend
 npm install
 ```
 
-### 5. Starta frontend (Vite)
+### 6. Starta frontend (Vite)
 ```bash
 npm run dev
 ```
@@ -60,7 +63,7 @@ npm run dev
 
 ---
 
-### 6. Testa att frontend <--> backend fungerar:
+### 7. Testa att frontend <--> backend fungerar:
 - Gå till frontend i webbläsaren
 - Klicka på "Testa backend-anslutning"
 - Du bör se: `Backend funkar!`

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,7 +15,11 @@ const {
   db,
 } = require("./orderDB");
 
-const SECRET = "hemligKod123"; // byt till process.env.JWT_SECRET i produktion
+const SECRET = process.env.JWT_SECRET;
+if (!SECRET) {
+  console.error("JWT_SECRET saknas. Lägg till variabeln i din miljö eller .env-fil.");
+  process.exit(1);
+}
 
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- add `.env.example`
- use `process.env.JWT_SECRET` in server and exit if missing
- document environment variable setup in README

## Testing
- `npm install` in `frontend`
- `npm run lint`
- `npm install` in `backend`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684025b4c6e0832eade17e6a1be49120