### PR TITLE
Use dotenv for JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ cd Annos
 ```bash
 cd backend
 npm install
+# Skapa .env med JWT_SECRET
+echo "JWT_SECRET=din-hemliga-kod" > .env
 # Kontrollera att du har express & cors
 npm list express
 npm list cors

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
+        "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "jsonwebtoken": "^9.0.2",
         "sqlite3": "^5.1.7"
@@ -505,6 +506,18 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "dotenv": "^16.5.0"
   }
 }

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
+require("dotenv").config();
 
 const app = express();
 const PORT = 3001;
@@ -15,7 +16,7 @@ const {
   db,
 } = require("./orderDB");
 
-const SECRET = "hemligKod123"; // byt till process.env.JWT_SECRET i produktion
+const SECRET = process.env.JWT_SECRET;
 
 app.use(cors());
 app.use(express.json());


### PR DESCRIPTION
## Summary
- add `dotenv` to backend dependencies
- load `.env` in `server.js`
- document `.env` usage in `README`

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68404413b3b0832eb9fc3eea5a632f3f