### PR TITLE
Fix checkout URL

### DIFF
--- a/frontend/src/Checkout.jsx
+++ b/frontend/src/Checkout.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "./App.css";
 
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 function Checkout({ varukorg, setVarukorg, restaurang }) {
   const navigate = useNavigate();
 
@@ -57,7 +59,7 @@ function Checkout({ varukorg, setVarukorg, restaurang }) {
       order: varukorg, // ✅ Skickar bara maträtter
     };
 
-    fetch("/api/order", {
+    fetch(`${BASE_URL}/api/order`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- use `VITE_API_BASE_URL` in `Checkout.jsx`
- update order fetch to respect env BASE_URL

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6844a30fa5bc832e8c18d419380da6a3