### PR TITLE
Remove unused sparaOrder

### DIFF
--- a/backend/orderDB.js
+++ b/backend/orderDB.js
@@ -34,34 +34,6 @@ db.serialize(() => {
   `);
 });
 
-// Spara order
-function sparaOrder(kund, order, callback) {
-  const sql = `
-    INSERT INTO orders (namn, telefon, email, adress, extraInfo, order_json, total, restaurangSlug)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `;
-  const jsonData = JSON.stringify(order.varor || []);
-  const total = order.total || 0;
-  const slug = order.restaurangSlug || "";
-
-  db.run(
-    sql,
-    [
-      kund.namn,
-      kund.telefon,
-      kund.email,
-      kund.adress,
-      kund.extraInfo || "",
-      jsonData,
-      total,
-      slug,
-    ],
-    function (err) {
-      if (err) return callback(err);
-      callback(null, this.lastID);
-    }
-  );
-}
 
 // Hämta senaste order
 function hamtaSenasteOrder(callback) {
@@ -97,7 +69,6 @@ function hamtaDagensOrdrar(callback) {
 }
 
 module.exports = {
-  sparaOrder,
   hamtaDagensOrdrar,
   hamtaSenasteOrder,
   markeraOrderSomKlar,


### PR DESCRIPTION
## Summary
- delete leftover `sparaOrder` helper
- update `orderDB.js` exports

## Testing
- `npm test` in `backend`
- `npm run lint` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_684592f7ddc4832e9fe1de2dfb58a902