### PR TITLE
Fix thank page redirect in strict mode

### DIFF
--- a/frontend/src/Tack.jsx
+++ b/frontend/src/Tack.jsx
@@ -1,17 +1,20 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import "./App.css";
 
 function Tack() {
   const navigate = useNavigate();
+  const initial = useRef({ done: false });
 
   useEffect(() => {
+    if (initial.current.done) return;
     const tillganglig = sessionStorage.getItem("tack");
     if (!tillganglig) {
       navigate("/");
     } else {
       sessionStorage.removeItem("tack");
     }
+    initial.current.done = true;
   }, [navigate]);
 
   return (


### PR DESCRIPTION
## Summary
- ensure thank page doesn't redirect to start when React StrictMode re-renders

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845c67888fc832eb3aafbe68b1f8cdc