### PR TITLE
Add admin role handling

### DIFF
--- a/backend/authMiddleware.js
+++ b/backend/authMiddleware.js
@@ -14,5 +14,14 @@ function verifyToken(req, res, next) {
   }
 }
 
-module.exports = verifyToken;
+function verifyAdmin(req, res, next) {
+  verifyToken(req, res, () => {
+    if (!req.user.isAdmin) {
+      return res.status(403).json({ error: "Ingen adminbehörighet" });
+    }
+    next();
+  });
+}
+
+module.exports = { verifyToken, verifyAdmin };
 

--- a/backend/orderDB.js
+++ b/backend/orderDB.js
@@ -29,7 +29,8 @@ db.serialize(() => {
       password TEXT,
       namn TEXT,
       telefon TEXT,
-      adress TEXT
+      adress TEXT,
+      isAdmin INTEGER DEFAULT 0
     )
   `);
 });

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -33,7 +33,7 @@ describe('API endpoints', () => {
       ]
     };
 
-    const token = jwt.sign({ userId: 1 }, SECRET);
+    const token = jwt.sign({ userId: 1, isAdmin: true }, SECRET);
     const res = await request(app)
       .post('/api/order')
       .set('Authorization', `Bearer ${token}`)
@@ -53,7 +53,7 @@ describe('API endpoints', () => {
   });
 
   test('PATCH /api/admin/orders/:id/klart marks order as done', async () => {
-    const token = jwt.sign({ userId: 1 }, SECRET);
+    const token = jwt.sign({ userId: 1, isAdmin: true }, SECRET);
 
     const newOrder = {
       kund: {

--- a/backend/skapaAdmin.js
+++ b/backend/skapaAdmin.js
@@ -12,8 +12,8 @@ const adress = "Testgatan 1";
 bcrypt.hash(losenord, 10, (err, hash) => {
   if (err) return console.error("❌ Fel vid hash:", err);
 
-  const sql = `INSERT INTO users (email, password, namn, telefon, adress) VALUES (?, ?, ?, ?, ?)`;
-  db.run(sql, [email, hash, namn, telefon, adress], function (err) {
+  const sql = `INSERT INTO users (email, password, namn, telefon, adress, isAdmin) VALUES (?, ?, ?, ?, ?, ?)`;
+  db.run(sql, [email, hash, namn, telefon, adress, 1], function (err) {
     if (err) {
       return console.error("❌ Kunde inte skapa användare:", err.message);
     }

--- a/frontend/src/Restaurang.jsx
+++ b/frontend/src/Restaurang.jsx
@@ -16,6 +16,11 @@ function Restaurang() {
         navigate("/login");
         return;
       }
+      const payload = JSON.parse(atob(token.split(".")[1]));
+      if (!payload.isAdmin) {
+        navigate("/");
+        return;
+      }
       const res = await fetch(`${BASE_URL}/api/admin/orders/today`, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -50,6 +55,11 @@ function Restaurang() {
       const token = localStorage.getItem("token");
       if (!token) {
         navigate("/login");
+        return;
+      }
+      const payload = JSON.parse(atob(token.split(".")[1]));
+      if (!payload.isAdmin) {
+        navigate("/");
         return;
       }
       const res = await fetch(`${BASE_URL}/api/admin/orders/${orderId}/klart`, {


### PR DESCRIPTION
## Summary
- add `isAdmin` column to `users`
- seed admin user with `isAdmin: 1`
- include admin flag in JWT and login response
- add `verifyAdmin` middleware and secure admin order routes
- update frontend admin page to verify admin from token
- update tests for admin tokens

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6845d4be0c74832e915e3844c16b4b35