### PR TITLE
Implement isAdmin support

### DIFF
--- a/backend/orderDB.js
+++ b/backend/orderDB.js
@@ -33,6 +33,12 @@ db.serialize(() => {
       isAdmin INTEGER DEFAULT 0
     )
   `);
+
+  db.all('PRAGMA table_info(users)', (err, cols) => {
+    if (!err && !cols.some((c) => c.name === 'isAdmin')) {
+      db.run('ALTER TABLE users ADD COLUMN isAdmin INTEGER DEFAULT 0');
+    }
+  });
 });
 
 


### PR DESCRIPTION
## Summary
- ensure `users` table always has `isAdmin` column
- keep `isAdmin` info in the login JWT
- use `verifyAdmin` middleware to guard admin routes
- restrict restaurant view on the frontend to admins

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6845dc853c78832e866ccfabcfb49970