### PR TITLE
Update server PORT and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ npm list cors
 Lägg till följande i `backend/.env`:
 ```
 JWT_SECRET=your-secret
+# Valfritt: ange egen port
+PORT=3001
 ```
 
 ### 4. Starta backend-servern

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,7 +9,7 @@ const dotenv = require("dotenv");
 dotenv.config();
 
 const app = express();
-const PORT = 3001;
+const PORT = process.env.PORT || 3001;
 const meny = require("./Data/menuData.js");
 const tillbehor = require("./Data/tillbehorData.js");
 const {


### PR DESCRIPTION
## Summary
- make backend listen on configurable PORT env var
- add PORT example to README

## Testing
- `npm run lint` in `frontend/`
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_6849b684723c832ea95a17793d066e3a