### PR TITLE
Add role-based auth

### DIFF
--- a/backend/authMiddleware.js
+++ b/backend/authMiddleware.js
@@ -14,14 +14,15 @@ function verifyToken(req, res, next) {
   }
 }
 
-function verifyAdmin(req, res, next) {
-  verifyToken(req, res, () => {
-    if (!req.user.isAdmin) {
-      return res.status(403).json({ error: "Ingen adminbehörighet" });
-    }
-    next();
-  });
+function verifyRole(requiredRole) {
+  return (req, res, next) => {
+    verifyToken(req, res, () => {
+      if (req.user.role !== requiredRole) {
+        return res.status(403).json({ error: "Otillräcklig behörighet" });
+      }
+      next();
+    });
+  };
 }
-
-module.exports = { verifyToken, verifyAdmin };
+module.exports = { verifyToken, verifyRole };
 

--- a/backend/migrateUserRoles.js
+++ b/backend/migrateUserRoles.js
@@ -1,0 +1,32 @@
+const sqlite3 = require("sqlite3").verbose();
+const path = require("path");
+
+const dbPath = path.join(__dirname, "orders.sqlite");
+const db = new sqlite3.Database(dbPath);
+
+// Lägg till kolumnen role om den saknas
+db.all("PRAGMA table_info(users)", (err, cols) => {
+  if (err) {
+    console.error(err);
+    return db.close();
+  }
+  if (!cols.some((c) => c.name === "role")) {
+    db.run("ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'customer'", runUpdate);
+  } else {
+    runUpdate();
+  }
+});
+
+function runUpdate() {
+  db.run(
+    "UPDATE users SET role = CASE WHEN isAdmin = 1 THEN 'admin' ELSE 'customer' END",
+    (err) => {
+      if (err) {
+        console.error(err);
+      } else {
+        console.log("Migrering klar");
+      }
+      db.close();
+    }
+  );
+}

--- a/backend/orderDB.js
+++ b/backend/orderDB.js
@@ -30,13 +30,13 @@ db.serialize(() => {
       namn TEXT,
       telefon TEXT,
       adress TEXT,
-      isAdmin INTEGER DEFAULT 0
+      role TEXT DEFAULT 'customer'
     )
   `);
 
   db.all('PRAGMA table_info(users)', (err, cols) => {
-    if (!err && !cols.some((c) => c.name === 'isAdmin')) {
-      db.run('ALTER TABLE users ADD COLUMN isAdmin INTEGER DEFAULT 0');
+    if (!err && !cols.some((c) => c.name === 'role')) {
+      db.run("ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'customer'");
     }
   });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,7 +2,7 @@ const express = require("express");
 const cors = require("cors");
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
-const { verifyToken, verifyAdmin } = require("./authMiddleware");
+const { verifyToken, verifyRole } = require("./authMiddleware");
 const { body, validationResult } = require("express-validator");
 const dotenv = require("dotenv");
 
@@ -98,7 +98,7 @@ app.post(
 });
 
 // ADMIN – HÄMTA ORDRAR
-app.get("/api/admin/orders/today", verifyAdmin, (req, res) => {
+app.get("/api/admin/orders/today", verifyRole("admin"), (req, res) => {
   hamtaDagensOrdrar((err, ordrar) => {
     if (err) {
       console.error("Fel vid hämtning av dagens ordrar:", err);
@@ -108,7 +108,7 @@ app.get("/api/admin/orders/today", verifyAdmin, (req, res) => {
   });
 });
 
-app.get("/api/admin/orders/latest", verifyAdmin, (req, res) => {
+app.get("/api/admin/orders/latest", verifyRole("admin"), (req, res) => {
   hamtaSenasteOrder((err, order) => {
     if (err) {
       console.error("Fel vid hämtning av senaste order:", err);
@@ -118,7 +118,7 @@ app.get("/api/admin/orders/latest", verifyAdmin, (req, res) => {
   });
 });
 
-app.patch("/api/admin/orders/:id/klart", verifyAdmin, (req, res) => {
+app.patch("/api/admin/orders/:id/klart", verifyRole("admin"), (req, res) => {
   const orderId = req.params.id;
   markeraOrderSomKlar(orderId, (err) => {
     if (err) {
@@ -187,7 +187,7 @@ app.post(
     }
 
     const token = jwt.sign(
-      { userId: user.id, isAdmin: user.isAdmin === 1 },
+      { userId: user.id, role: user.role },
       process.env.JWT_SECRET,
       { expiresIn: "7d" }
     );
@@ -198,7 +198,7 @@ app.post(
       email: user.email,
       telefon: user.telefon,
       adress: user.adress || "",
-      isAdmin: user.isAdmin === 1,
+      role: user.role,
     });
   });
 });

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -33,7 +33,7 @@ describe('API endpoints', () => {
       ]
     };
 
-    const token = jwt.sign({ userId: 1, isAdmin: true }, SECRET);
+    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
     const res = await request(app)
       .post('/api/order')
       .set('Authorization', `Bearer ${token}`)
@@ -53,7 +53,7 @@ describe('API endpoints', () => {
   });
 
   test('PATCH /api/admin/orders/:id/klart marks order as done', async () => {
-    const token = jwt.sign({ userId: 1, isAdmin: true }, SECRET);
+    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
 
     const newOrder = {
       kund: {

--- a/backend/skapaAdmin.js
+++ b/backend/skapaAdmin.js
@@ -12,8 +12,8 @@ const adress = "Testgatan 1";
 bcrypt.hash(losenord, 10, (err, hash) => {
   if (err) return console.error("❌ Fel vid hash:", err);
 
-  const sql = `INSERT INTO users (email, password, namn, telefon, adress, isAdmin) VALUES (?, ?, ?, ?, ?, ?)`;
-  db.run(sql, [email, hash, namn, telefon, adress, 1], function (err) {
+  const sql = `INSERT INTO users (email, password, namn, telefon, adress, role) VALUES (?, ?, ?, ?, ?, ?)`;
+  db.run(sql, [email, hash, namn, telefon, adress, 'admin'], function (err) {
     if (err) {
       return console.error("❌ Kunde inte skapa användare:", err.message);
     }

--- a/frontend/src/AdminPanel.jsx
+++ b/frontend/src/AdminPanel.jsx
@@ -21,7 +21,7 @@ function AdminPanel() {
 
     try {
       const payload = JSON.parse(atob(token.split(".")[1]));
-      if (!payload.isAdmin) {
+      if (payload.role !== "admin") {
         navigate("/");
       }
     } catch (err) {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,18 +33,20 @@ function App() {
   });
   const [tillbehor, setTillbehor] = useState([]);
   const [inloggad, setInloggad] = useState(!!localStorage.getItem("token"));
-  const [isAdmin, setIsAdmin] = useState(() => {
+  const [role, setRole] = useState(() => {
     const t = localStorage.getItem("token");
     if (!t) {
-      return false;
+      return "";
     }
     try {
       const payload = JSON.parse(atob(t.split(".")[1]));
-      return !!payload.isAdmin;
+      return payload.role || "";
     } catch {
-      return false;
+      return "";
     }
   });
+  const isAdmin = role === "admin";
+  const isCourier = role === "courier";
   const [tema, setTema] = useState(
     () => localStorage.getItem("tema") || "light"
   );
@@ -107,14 +109,14 @@ function App() {
       const tok = localStorage.getItem("token");
       setInloggad(!!tok);
       if (!tok) {
-        setIsAdmin(false);
+        setRole("");
         return;
       }
       try {
         const payload = JSON.parse(atob(tok.split(".")[1]));
-        setIsAdmin(!!payload.isAdmin);
+        setRole(payload.role || "");
       } catch {
-        setIsAdmin(false);
+        setRole("");
       }
     };
     window.addEventListener("storage", observer);
@@ -162,6 +164,9 @@ function App() {
                   <button onClick={() => navigate("/admin")}>
                     🛠 Adminpanel
                   </button>
+                )}
+                {isCourier && (
+                  <button onClick={() => navigate("/kurir")}>🚚 Kurirpanel</button>
                 )}
                 <button
                   onClick={() => {
@@ -303,7 +308,7 @@ function App() {
             🛒 Kundvagn ({varukorg.length})
           </button>
         )}
-        {isAdmin && <button onClick={() => navigate("/kurir")}>🚚 Kurirpanel</button>}
+        {isCourier && <button onClick={() => navigate("/kurir")}>🚚 Kurirpanel</button>}
 
     </>
   );

--- a/frontend/src/KurirVy.jsx
+++ b/frontend/src/KurirVy.jsx
@@ -19,7 +19,7 @@ function KurirVy() {
 
     try {
       const payload = JSON.parse(atob(token.split(".")[1]));
-      if (!payload.isAdmin) {
+      if (payload.role !== "courier") {
         navigate("/");
       }
     } catch {
@@ -32,7 +32,9 @@ function KurirVy() {
       const res = await fetch(`${BASE_URL}/api/admin/orders/today`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (!res.ok) throw new Error("Kunde inte hämta ordrar");
+      if (!res.ok) {
+        throw new Error("Kunde inte hämta ordrar");
+      }
       const data = await res.json();
       setOrdrar(data);
     } catch (err) {
@@ -51,9 +53,12 @@ function KurirVy() {
         method: "PATCH",
         headers: { Authorization: `Bearer ${token}` },
       });
-      if (!res.ok) throw new Error("Kunde inte markera som klar");
+      if (!res.ok) {
+        throw new Error("Kunde inte markera som klar");
+      }
       setOrdrar((prev) => prev.filter((o) => o.id !== id));
     } catch (err) {
+      console.error(err);
       alert("❌ Kunde inte markera som levererad.");
     }
   };

--- a/frontend/src/Restaurang.jsx
+++ b/frontend/src/Restaurang.jsx
@@ -17,7 +17,7 @@ function Restaurang() {
         return;
       }
       const payload = JSON.parse(atob(token.split(".")[1]));
-      if (!payload.isAdmin) {
+      if (payload.role !== "admin") {
         navigate("/");
         return;
       }
@@ -58,7 +58,7 @@ function Restaurang() {
         return;
       }
       const payload = JSON.parse(atob(token.split(".")[1]));
-      if (!payload.isAdmin) {
+      if (payload.role !== "admin") {
         navigate("/");
         return;
       }


### PR DESCRIPTION
## Summary
- switch to role-based auth and update login token
- restrict admin and courier views by role
- update tests and frontend to use role field
- provide migration script for converting existing users

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f295a4b00832e83ee8f07e450c599