### PR TITLE
Use cookie based access tokens

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "apple-signin-auth": "^2.0.0",
         "bcrypt": "^6.0.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^5.1.0",
@@ -1972,6 +1973,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,14 +1,15 @@
 {
   "dependencies": {
+    "apple-signin-auth": "^2.0.0",
     "bcrypt": "^6.0.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^5.1.0",
     "express-validator": "^7.2.1",
-    "jsonwebtoken": "^9.0.2",
-    "sqlite3": "^5.1.7",
     "google-auth-library": "^9.0.0",
-    "apple-signin-auth": "^2.0.0"
+    "jsonwebtoken": "^9.0.2",
+    "sqlite3": "^5.1.7"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -32,7 +32,8 @@ router.post("/login", [
 
     const { accessToken, refreshToken } = generateTokens(user);
     res.cookie("refreshToken", refreshToken, { httpOnly: true, maxAge: 604800000 });
-    res.json({ accessToken });
+    res.cookie("accessToken", accessToken, { httpOnly: true, sameSite: "lax", maxAge: 15 * 60 * 1000 });
+    res.json({});
   });
 });
 
@@ -50,7 +51,8 @@ router.post("/google", async (req, res) => {
     const handleUser = (id) => {
       const { accessToken, refreshToken } = generateTokens({ id, role: "customer" });
       res.cookie("refreshToken", refreshToken, { httpOnly: true, maxAge: 604800000 });
-      res.json({ accessToken });
+      res.cookie("accessToken", accessToken, { httpOnly: true, sameSite: "lax", maxAge: 15 * 60 * 1000 });
+      res.json({});
     };
 
     if (!user) {
@@ -80,7 +82,8 @@ router.post("/apple", async (req, res) => {
       const handleUser = (id) => {
         const { accessToken, refreshToken } = generateTokens({ id, role: "customer" });
         res.cookie("refreshToken", refreshToken, { httpOnly: true, maxAge: 604800000 });
-        res.json({ accessToken });
+        res.cookie("accessToken", accessToken, { httpOnly: true, sameSite: "lax", maxAge: 15 * 60 * 1000 });
+        res.json({});
       };
 
       if (!user) {
@@ -107,7 +110,8 @@ router.post("/refresh", (req, res) => {
     db.get("SELECT id, role FROM users WHERE id = ?", [payload.userId], (err, user) => {
       if (err || !user) return res.status(401).json({ error: "Ogiltig användare" });
       const accessToken = jwt.sign({ userId: user.id, role: user.role }, process.env.JWT_SECRET, { expiresIn: "15m" });
-      res.json({ accessToken });
+      res.cookie("accessToken", accessToken, { httpOnly: true, sameSite: "lax", maxAge: 15 * 60 * 1000 });
+      res.json({});
     });
   } catch {
     res.status(403).json({ error: "Ogiltig refresh token" });
@@ -116,6 +120,7 @@ router.post("/refresh", (req, res) => {
 
 // 🚪 Logout
 router.post("/logout", (req, res) => {
+  res.clearCookie("accessToken");
   res.clearCookie("refreshToken");
   res.json({ message: "Utloggad" });
 });

--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ const express = require("express");
 const cors = require("cors");
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
+const cookieParser = require("cookie-parser");
 const { verifyToken, verifyRole } = require("./authMiddleware");
 const { body, validationResult } = require("express-validator");
 const dotenv = require("dotenv");
@@ -23,6 +24,7 @@ const {
 
 app.use(cors());
 app.use(express.json());
+app.use(cookieParser());
 app.use('/api/auth', authRouter);
 
 app.get("/", (req, res) => {
@@ -188,14 +190,19 @@ app.post(
       return res.status(401).json({ error: "Fel e-post eller lösenord" });
     }
 
-    const token = jwt.sign(
+    const accessToken = jwt.sign(
       { userId: user.id, role: user.role },
       process.env.JWT_SECRET,
       { expiresIn: "7d" }
     );
 
+    res.cookie("accessToken", accessToken, {
+      httpOnly: true,
+      sameSite: "lax",
+      maxAge: 15 * 60 * 1000,
+    });
+
     res.json({
-      token,
       namn: user.namn,
       email: user.email,
       telefon: user.telefon,


### PR DESCRIPTION
## Summary
- install `cookie-parser`
- apply `cookie-parser` in `server.js`
- set `accessToken` via cookie for email login and OAuth logins
- refresh endpoint now issues `accessToken` cookie
- adjust standard login to return user info without token
- clear both cookies on logout

## Testing
- `npm test` in `backend`
- `npm run lint` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_68507b0732a4832eb218a043222cd50a