### PR TITLE
Add cookie fallback for verifyToken

### DIFF
--- a/backend/authMiddleware.js
+++ b/backend/authMiddleware.js
@@ -1,7 +1,12 @@
 const jwt = require("jsonwebtoken");
 
 function verifyToken(req, res, next) {
-  const token = req.headers.authorization?.split(" ")[1];
+  let token;
+  if (req.headers.authorization) {
+    token = req.headers.authorization.split(" ")[1];
+  } else if (req.cookies.accessToken) {
+    token = req.cookies.accessToken;
+  }
   if (!token) {
     return res.status(401).json({ error: "Ingen token" });
   }

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -52,6 +52,30 @@ describe('API endpoints', () => {
     expect(inserted.namn).toBe(newOrder.kund.namn);
   });
 
+  test('POST /api/order works with cookie token', async () => {
+    const newOrder = {
+      kund: {
+        namn: 'Cookie Testsson',
+        telefon: '111222333',
+        adress: 'Cookiegatan 3',
+        ovrigt: 'Inga',
+        email: `cookie_${Date.now()}@example.com`
+      },
+      order: [
+        { id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }
+      ]
+    };
+
+    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
+    const res = await request(app)
+      .post('/api/order')
+      .set('Cookie', [`accessToken=${token}`])
+      .send(newOrder);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body).toHaveProperty('orderId');
+  });
+
   test('PATCH /api/admin/orders/:id/klart marks order as done', async () => {
     const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
 


### PR DESCRIPTION
## Summary
- allow verifyToken to read accessToken from cookies when Authorization header is missing
- test cookie-based authentication in the API tests

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68507f1d5350832eb36713c40f0ff1ff