### PR TITLE
Add FRONTEND_ORIGIN env docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ REFRESH_SECRET=your-refresh-secret
 # OAuth-nycklar
 GOOGLE_CLIENT_ID=din-google-client-id
 APPLE_CLIENT_ID=din-apple-client-id
+# Adressen som får skicka cookies till backend
+FRONTEND_ORIGIN=http://localhost:5173
 # Valfritt: ange egen port
 PORT=3001
 ```


### PR DESCRIPTION
## Summary
- document `FRONTEND_ORIGIN` variable in the backend `.env` instructions

## Testing
- `npm run lint` in `frontend/`
- `npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_68508fce2eac832e95d6eba406a9a159