### PR TITLE
Switch login to JWT cookies

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -200,6 +200,11 @@ app.post(
       const accessToken = jwt.sign(
         { userId: user.id, role: user.role },
         process.env.JWT_SECRET,
+        { expiresIn: "15m" }
+      );
+      const refreshToken = jwt.sign(
+        { userId: user.id },
+        process.env.REFRESH_SECRET,
         { expiresIn: "7d" }
       );
 
@@ -207,6 +212,10 @@ app.post(
         httpOnly: true,
         sameSite: "lax",
         maxAge: 15 * 60 * 1000,
+      });
+      res.cookie("refreshToken", refreshToken, {
+        httpOnly: true,
+        maxAge: 7 * 24 * 60 * 60 * 1000,
       });
 
       res.json({

--- a/frontend/src/Login.jsx
+++ b/frontend/src/Login.jsx
@@ -13,14 +13,13 @@ function Login() {
       const res = await fetch(`${BASE_URL}/api/auth/login`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ email, losenord }),
       });
 
       const data = await res.json();
 
       if (res.ok) {
-        localStorage.setItem("token", data.token);
-
         // 🔐 Spara användarinfo för profil & checkout
         localStorage.setItem("kundinfo", JSON.stringify({
           namn: data.namn,
@@ -45,13 +44,13 @@ function Login() {
       const res = await fetch(`${BASE_URL}/api/auth/google`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ token: window.googleToken || "" }),
       });
 
-      const data = await res.json();
+      await res.json();
 
       if (res.ok) {
-        localStorage.setItem("token", data.accessToken);
         window.dispatchEvent(new Event("storage"));
         navigate("/valj-restaurang");
       } else {
@@ -68,13 +67,13 @@ function Login() {
       const res = await fetch(`${BASE_URL}/api/auth/apple`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ identityToken: window.appleToken || "" }),
       });
 
-      const data = await res.json();
+      await res.json();
 
       if (res.ok) {
-        localStorage.setItem("token", data.accessToken);
         window.dispatchEvent(new Event("storage"));
         navigate("/valj-restaurang");
       } else {


### PR DESCRIPTION
## Summary
- store JWTs only in HTTP-only cookies
- use cookies for login requests from frontend

## Testing
- `npm run lint` in `frontend/`
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_685090e09c18832ebc7713f06cb69b80