### PR TITLE
Update backend check in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,8 @@ npm run dev
 ---
 
 ### 9. Testa att frontend <--> backend fungerar:
-- Gå till frontend i webbläsaren
-- Klicka på "Testa backend-anslutning"
-- Du bör se: `Backend funkar!`
+- Öppna http://localhost:3001 i webbläsaren eller kör `curl http://localhost:3001` i terminalen.
+- Du bör se: `backend funkar!`
 ### 10. Kör kodkvalitetskontroller
 ```bash
 cd frontend


### PR DESCRIPTION
## Summary
- replace outdated step for verifying backend connection in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685692e60538832eac4e0628130a1a56