### PR TITLE
Improve admin setup notes and warn on missing admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Gå till mappen `backend` och kör skriptet för att skapa ett första administr
 cd backend
 node skapaAdmin.js
 ```
-När både backend och frontend körs kan du navigera till `/admin` för att logga in med dessa uppgifter.
+**Detta måste köras innan du kan logga in på `/admin`.** När både backend och frontend körs kan du sedan navigera till `/admin` för att logga in med dessa uppgifter.
 
 ### 6. Starta backend-servern
 ```bash

--- a/backend/server.js
+++ b/backend/server.js
@@ -286,8 +286,18 @@ app.get("/api/my-orders", verifyToken, (req, res) => {
 });
 
 if (require.main === module) {
-  app.listen(PORT, () => {
-    console.log(`Servern körs på http://localhost:${PORT}`);
+  db.get("SELECT id FROM users WHERE role = 'admin' LIMIT 1", (err, row) => {
+    if (err) {
+      console.error('Fel vid kontroll av admin-anv\xE4ndare:', err.message);
+    } else if (!row) {
+      console.warn(
+        '⚠️ Inget admin-konto hittades. Kör "node backend/skapaAdmin.js" innan du loggar in på /admin.'
+      );
+    }
+
+    app.listen(PORT, () => {
+      console.log(`Servern körs på http://localhost:${PORT}`);
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- mention that `node skapaAdmin.js` must be run before logging in to `/admin`
- log a warning in `server.js` if no admin account exists

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856f9eef95c832e99d6ce33dd921cba