### PR TITLE
Add dark mode awareness to UI

### DIFF
--- a/frontend/src/AdminPanel.jsx
+++ b/frontend/src/AdminPanel.jsx
@@ -69,7 +69,7 @@ function AdminPanel() {
     }
   };
 
-  const tema = localStorage.getItem("tema") === "dark";
+  const darkMode = document.body.classList.contains("dark");
 
   return (
     <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
@@ -96,8 +96,8 @@ function AdminPanel() {
             <div
               key={order.id}
               style={{
-                backgroundColor: tema ? "#2a2a2a" : "#f5f5f5",
-                color: tema ? "white" : "black",
+                backgroundColor: darkMode ? "#2a2a2a" : "#f5f5f5",
+                color: darkMode ? "white" : "black",
                 border: "1px solid #ccc",
                 padding: "1rem",
                 marginBottom: "1.5rem",

--- a/frontend/src/Checkout.jsx
+++ b/frontend/src/Checkout.jsx
@@ -7,6 +7,7 @@ const BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
 function Checkout({ varukorg, setVarukorg, restaurang }) {
   const navigate = useNavigate();
+  const darkMode = document.body.classList.contains("dark");
 
   const [kundinfo, setKundinfo] = useState({
     namn: "",
@@ -145,13 +146,16 @@ function Checkout({ varukorg, setVarukorg, restaurang }) {
             flexWrap: "wrap",
           }}
         >
-          <button type="submit" style={{ backgroundColor: "green", color: "white" }}>
+          <button
+            type="submit"
+            style={{ backgroundColor: darkMode ? "#2e7031" : "green", color: "white" }}
+          >
             ✅ Bekräfta ({totalPris} kr)
           </button>
           <button
             type="button"
             onClick={() => navigate("/kundvagn")}
-            style={{ backgroundColor: "#444", color: "white" }}
+            style={{ backgroundColor: darkMode ? "#333" : "#444", color: "white" }}
           >
             🛒 Tillbaka till kundvagn
           </button>

--- a/frontend/src/KurirVy.jsx
+++ b/frontend/src/KurirVy.jsx
@@ -9,6 +9,7 @@ function KurirVy() {
   const navigate = useNavigate();
   const [ordrar, setOrdrar] = useState([]);
   const [fel, setFel] = useState(null);
+  const darkMode = document.body.classList.contains("dark");
 
   useEffect(() => {
     const check = async () => {
@@ -72,7 +73,8 @@ function KurirVy() {
             marginBottom: "1.5rem",
             padding: "1rem",
             borderRadius: "10px",
-            backgroundColor: "#f0f8ff",
+            backgroundColor: darkMode ? "#2a2a2a" : "#f0f8ff",
+            color: darkMode ? "white" : "black",
           }}
         >
           <p>

--- a/frontend/src/Restaurang.jsx
+++ b/frontend/src/Restaurang.jsx
@@ -86,7 +86,7 @@ function Restaurang() {
     });
   };
 
-  const ärMörktLäge = localStorage.getItem("tema") === "dark";
+  const darkMode = document.body.classList.contains("dark");
 
   return (
     <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
@@ -138,7 +138,7 @@ function Restaurang() {
           if (order.status === "klar") {färg = "lightgreen";}
           else if (diffMin < 1) {färg = "lightcoral";}
 
-          if (ärMörktLäge) {
+          if (darkMode) {
             if (order.status === "klar") {färg = "#2e7031";}
             else if (diffMin < 1) {färg = "#803333";}
             else {färg = "#2a2a2a";}
@@ -154,7 +154,7 @@ function Restaurang() {
                 marginBottom: "1.5rem",
                 borderRadius: "10px",
                 backgroundColor: färg,
-                color: ärMörktLäge ? "white" : "black", // 🔧 säkrar färg
+                color: darkMode ? "white" : "black", // 🔧 säkrar färg
               }}
             >
               <p>

--- a/frontend/src/Start.jsx
+++ b/frontend/src/Start.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 function Start() {
   const navigate = useNavigate();
   const [visaInfo, setVisaInfo] = useState(null); // "om", "support", "villkor"
+  const darkMode = document.body.classList.contains("dark");
 
   const öppnaInfo = (typ) => {
     setVisaInfo(typ);
@@ -67,13 +68,13 @@ function Start() {
           zIndex: 9999
         }}>
           <div style={{
-            background: "white",
+            background: darkMode ? "#333" : "white",
             padding: "2rem",
             borderRadius: "10px",
             maxWidth: "500px",
             width: "90%",
             textAlign: "center",
-            color: "black"
+            color: darkMode ? "white" : "black"
           }}>
             <h2>{texter[visaInfo].titel}</h2>
             <p style={{ whiteSpace: "pre-wrap" }}>{texter[visaInfo].innehåll}</p>
@@ -83,7 +84,7 @@ function Start() {
       )}
 
       {/* Footer med länkar */}
-      <footer style={{ marginTop: "4rem", fontSize: "0.9rem", color: "gray" }}>
+      <footer style={{ marginTop: "4rem", fontSize: "0.9rem", color: darkMode ? "#ccc" : "gray" }}>
         <p>
           Vi lagrar dina uppgifter enligt GDPR och använder dem endast för att hantera din beställning.
         </p>

--- a/frontend/src/Tack.jsx
+++ b/frontend/src/Tack.jsx
@@ -5,6 +5,7 @@ import "./App.css";
 function Tack() {
   const navigate = useNavigate();
   const initial = useRef({ done: false });
+  const darkMode = document.body.classList.contains("dark");
 
   useEffect(() => {
     if (initial.current.done) {
@@ -45,14 +46,14 @@ function Tack() {
         <button
           type="button"
           onClick={() => navigate("/valj-restaurang")}
-          style={{ backgroundColor: "#4caf50", color: "white" }}
+          style={{ backgroundColor: darkMode ? "#2e7031" : "#4caf50", color: "white" }}
         >
           🍽️ Till restauranger
         </button>
         <button
           type="button"
           onClick={() => navigate("/profil")}
-          style={{ backgroundColor: "#1976d2", color: "white" }}
+          style={{ backgroundColor: darkMode ? "#125290" : "#1976d2", color: "white" }}
         >
           👤 Min profil
         </button>
@@ -64,7 +65,7 @@ function Tack() {
             alert("Du är nu utloggad.");
             navigate("/");
           }}
-          style={{ backgroundColor: "#f44336", color: "white" }}
+          style={{ backgroundColor: darkMode ? "#802b2b" : "#f44336", color: "white" }}
         >
           🚪 Logga ut
         </button>

--- a/frontend/src/Undermeny.jsx
+++ b/frontend/src/Undermeny.jsx
@@ -4,6 +4,7 @@ import "./App.css";
 function Undermeny({ ratt, tillbehor, onClose, onAddToCart, isLoggedIn }) {
   const [oppenKategori, setOppenKategori] = useState(null);
  const kategoriRefs = useRef({});
+  const darkMode = document.body.classList.contains("dark");
 
   const [valda, setValda] = useState({});
   const [valfriSasText, setValfriSasText] = useState("");
@@ -131,7 +132,10 @@ function Undermeny({ ratt, tillbehor, onClose, onAddToCart, isLoggedIn }) {
       <div className="modal-content" style={{ display: "flex", flexDirection: "column", height: "90vh", padding: 0 }}>
         {/* Sticky Header */}
         <div style={{ position: "sticky", top: 0, zIndex: 20, background: "inherit", padding: "1rem" }}>
-          <button onClick={onClose} style={{ backgroundColor: "#dc3545", color: "white", width: "100%" }}>
+          <button
+            onClick={onClose}
+            style={{ backgroundColor: darkMode ? "#802b2b" : "#dc3545", color: "white", width: "100%" }}
+          >
             ❌ Stäng undermeny
           </button>
           <div style={{ display: "flex", flexWrap: "wrap", gap: "0.5rem", justifyContent: "center", marginTop: "0.5rem" }}>

--- a/frontend/src/ValjRestaurang.jsx
+++ b/frontend/src/ValjRestaurang.jsx
@@ -2,6 +2,7 @@ import { useNavigate } from "react-router-dom";
 
 function ValjRestaurang() {
   const navigate = useNavigate();
+  const darkMode = document.body.classList.contains("dark");
 
   const restauranger = [
     {
@@ -32,8 +33,9 @@ function ValjRestaurang() {
               cursor: "pointer",
               padding: "1rem",
               borderRadius: "12px",
-              backgroundColor: "#f5f5f5",
+              backgroundColor: darkMode ? "#333" : "#f5f5f5",
               boxShadow: "0 2px 8px rgba(0,0,0,0.1)",
+              color: darkMode ? "white" : "black",
               maxWidth: "200px",
               width: "100%",
             }}


### PR DESCRIPTION
## Summary
- adjust components to check for dark theme
- style modals and cards based on theme

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68585d5a1c80832eb194cf17667f7321