### PR TITLE
Sync theme on profile page

### DIFF
--- a/frontend/src/MinProfil.jsx
+++ b/frontend/src/MinProfil.jsx
@@ -8,7 +8,23 @@ function MinProfil() {
   const navigate = useNavigate();
   const [aktiv, setAktiv] = useState("info");
   const [profil, setProfil] = useState(null);
-  const darkMode = document.body.classList.contains("dark");
+  const [tema, setTema] = useState(() => localStorage.getItem("tema") || "light");
+  const darkMode = tema === "dark";
+
+  useEffect(() => {
+    document.body.className = tema;
+  }, [tema]);
+
+  useEffect(() => {
+    const handleStorage = () => {
+      const lagrat = localStorage.getItem("tema") || "light";
+      setTema(lagrat);
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
 
    useEffect(() => {
     const load = async () => {


### PR DESCRIPTION
## Summary
- sync `tema` state with localStorage in profile view
- update sidebar to respect dark mode state

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68585f18c27c832e904dd66aa1453c0d