### PR TITLE
Add restaurant slug to user handling

### DIFF
--- a/backend/initDB.js
+++ b/backend/initDB.js
@@ -22,7 +22,8 @@ db.serialize(() => {
       telefon TEXT,
       adress TEXT,
       password TEXT,
-      role TEXT DEFAULT 'customer'
+      role TEXT DEFAULT 'customer',
+      restaurangSlug TEXT
     )`,
     (err) => {
       if (err) {

--- a/backend/migrateRestaurangSlug.js
+++ b/backend/migrateRestaurangSlug.js
@@ -1,0 +1,24 @@
+const sqlite3 = require("sqlite3").verbose();
+const path = require("path");
+
+const dbPath = path.join(__dirname, "orders.sqlite");
+const db = new sqlite3.Database(dbPath);
+
+// Lägg till kolumnen restaurangSlug om den saknas
+
+db.all("PRAGMA table_info(users)", (err, cols) => {
+  if (err) {
+    console.error(err);
+    return db.close();
+  }
+  if (!cols.some((c) => c.name === "restaurangSlug")) {
+    db.run("ALTER TABLE users ADD COLUMN restaurangSlug TEXT", closeDb);
+  } else {
+    closeDb();
+  }
+});
+
+function closeDb() {
+  console.log("Migrering klar");
+  db.close();
+}

--- a/backend/orderDB.js
+++ b/backend/orderDB.js
@@ -30,13 +30,17 @@ db.serialize(() => {
       namn TEXT,
       telefon TEXT,
       adress TEXT,
-      role TEXT DEFAULT 'customer'
+      role TEXT DEFAULT 'customer',
+      restaurangSlug TEXT
     )
   `);
 
   db.all('PRAGMA table_info(users)', (err, cols) => {
     if (!err && !cols.some((c) => c.name === 'role')) {
       db.run("ALTER TABLE users ADD COLUMN role TEXT DEFAULT 'customer'");
+    }
+    if (!err && !cols.some((c) => c.name === 'restaurangSlug')) {
+      db.run("ALTER TABLE users ADD COLUMN restaurangSlug TEXT");
     }
   });
 });

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -64,7 +64,14 @@ router.post(
           sameSite: "lax",
           maxAge: 15 * 60 * 1000,
         });
-        res.json({});
+        res.json({
+          namn: user.namn,
+          email: user.email,
+          telefon: user.telefon,
+          adress: user.adress || "",
+          role: user.role,
+          restaurangSlug: user.restaurangSlug || "",
+        });
       }
     );
   }

--- a/backend/server.js
+++ b/backend/server.js
@@ -225,6 +225,7 @@ app.post(
         telefon: user.telefon,
         adress: user.adress || "",
         role: user.role,
+        restaurangSlug: user.restaurangSlug || "",
       });
     });
   }
@@ -235,7 +236,7 @@ app.get("/api/profile", verifyToken, (req, res) => {
   const userId = req.user.userId;
 
   db.get(
-    "SELECT id, email, namn, telefon, adress FROM users WHERE id = ?",
+    "SELECT id, email, namn, telefon, adress, restaurangSlug FROM users WHERE id = ?",
     [userId],
     (err, user) => {
       if (err || !user) {
@@ -256,6 +257,7 @@ app.get("/api/profile", verifyToken, (req, res) => {
           email: user.email,
           telefon: user.telefon,
           adress: user.adress,
+          restaurangSlug: user.restaurangSlug || "",
           bestallningar: orders || [],
         });
       });

--- a/backend/skapaAdmin.js
+++ b/backend/skapaAdmin.js
@@ -8,16 +8,17 @@ const losenord = "admin123";
 const namn = "Admin Test";
 const telefon = "0700000000";
 const adress = "Testgatan 1";
+const restaurangSlug = process.argv[2] || "campino";
 
 bcrypt.hash(losenord, 10, (err, hash) => {
   if (err) return console.error("❌ Fel vid hash:", err);
 
-  const sql = `INSERT INTO users (email, password, namn, telefon, adress, role) VALUES (?, ?, ?, ?, ?, ?)`;
-  db.run(sql, [email, hash, namn, telefon, adress, 'admin'], function (err) {
+  const sql = `INSERT INTO users (email, password, namn, telefon, adress, role, restaurangSlug) VALUES (?, ?, ?, ?, ?, ?, ?)`;
+  db.run(sql, [email, hash, namn, telefon, adress, 'admin', restaurangSlug], function (err) {
     if (err) {
       return console.error("❌ Kunde inte skapa användare:", err.message);
     }
-    console.log(`✅ Användare skapad med ID ${this.lastID}`);
+    console.log(`✅ Användare skapad med ID ${this.lastID} för slug ${restaurangSlug}`);
     db.close();
   });
 });


### PR DESCRIPTION
## Summary
- extend users table with `restaurangSlug`
- include new migration script
- allow admin creation with slug
- expose slug from login and profile endpoints
- adjust DB helpers for slug column

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68598770ae3c832e8862fd3a0a16a23c