### PR TITLE
Filter orders by restaurant slug

### DIFF
--- a/backend/orderDB.js
+++ b/backend/orderDB.js
@@ -65,15 +65,16 @@ function markeraOrderSomKlar(orderId, callback) {
 }
 
 // Hämta dagens ordrar
-function hamtaDagensOrdrar(callback) {
+function hamtaDagensOrdrar(restaurangSlug, callback) {
   const idag = new Date().toISOString().split("T")[0];
   const sql = `
-    SELECT * FROM orders 
-    WHERE DATE(created_at) = ?
-    AND (status = 'aktiv' OR (status = 'klar' AND created_at >= datetime('now', '-5 minutes')))
-    ORDER BY created_at DESC
-  `;
-  db.all(sql, [idag], (err, rows) => {
+      SELECT * FROM orders
+      WHERE DATE(created_at) = ?
+        AND restaurangSlug = ?
+        AND (status = 'aktiv' OR (status = 'klar' AND created_at >= datetime('now', '-5 minutes')))
+      ORDER BY created_at DESC
+    `;
+  db.all(sql, [idag, restaurangSlug], (err, rows) => {
     if (err) return callback(err);
     callback(null, rows);
   });

--- a/backend/server.js
+++ b/backend/server.js
@@ -112,7 +112,11 @@ app.post(
 
 // ADMIN – HÄMTA ORDRAR
 app.get("/api/admin/orders/today", verifyRole("admin"), (req, res) => {
-  hamtaDagensOrdrar((err, ordrar) => {
+  const { slug } = req.query;
+  if (!slug) {
+    return res.status(400).json({ message: "Slug saknas" });
+  }
+  hamtaDagensOrdrar(slug, (err, ordrar) => {
     if (err) {
       console.error("Fel vid hämtning av dagens ordrar:", err);
       return res.status(500).json({ message: "Serverfel" });

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -126,4 +126,50 @@ describe('API endpoints', () => {
       .send({});
     expect(res.statusCode).toBe(401);
   });
+
+  test('GET /api/admin/orders/today filters by slug', async () => {
+    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
+
+    const order1 = {
+      kund: {
+        namn: 'Slug Test1',
+        telefon: '000',
+        adress: 'A',
+        ovrigt: 'Inga',
+        email: `slug1_${Date.now()}@example.com`
+      },
+      order: [{ id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }],
+      restaurangSlug: 'campino'
+    };
+
+    const order2 = {
+      kund: {
+        namn: 'Slug Test2',
+        telefon: '111',
+        adress: 'B',
+        ovrigt: 'Inga',
+        email: `slug2_${Date.now()}@example.com`
+      },
+      order: [{ id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }],
+      restaurangSlug: 'bistro'
+    };
+
+    await request(app)
+      .post('/api/order')
+      .set('Authorization', `Bearer ${token}`)
+      .send(order1);
+
+    await request(app)
+      .post('/api/order')
+      .set('Authorization', `Bearer ${token}`)
+      .send(order2);
+
+    const res = await request(app)
+      .get('/api/admin/orders/today?slug=campino')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(res.statusCode).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.every(o => o.restaurangSlug === 'campino')).toBe(true);
+  });
 });

--- a/frontend/src/AdminPanel.jsx
+++ b/frontend/src/AdminPanel.jsx
@@ -31,9 +31,13 @@ function AdminPanel() {
   const hamtaOrdrar = useCallback(async () => {
     setLoading(true);
     try {
-      const res = await fetch(`${BASE_URL}/api/admin/orders/today`, {
-        credentials: "include",
-      });
+      const profil = await fetchProfile();
+      const res = await fetch(
+        `${BASE_URL}/api/admin/orders/today?slug=${profil.restaurangSlug}`,
+        {
+          credentials: "include",
+        }
+      );
       if (!res.ok) {
         throw new Error("Kunde inte hämta ordrar");
       }

--- a/frontend/src/KurirVy.jsx
+++ b/frontend/src/KurirVy.jsx
@@ -27,9 +27,13 @@ function KurirVy() {
 
   const hämtaOrdrar = useCallback(async () => {
     try {
-      const res = await fetch(`${BASE_URL}/api/admin/orders/today`, {
-        credentials: "include",
-      });
+      const profil = await fetchProfile();
+      const res = await fetch(
+        `${BASE_URL}/api/admin/orders/today?slug=${profil.restaurangSlug}`,
+        {
+          credentials: "include",
+        }
+      );
       if (!res.ok) {
         throw new Error("Kunde inte hämta ordrar");
       }

--- a/frontend/src/Restaurang.jsx
+++ b/frontend/src/Restaurang.jsx
@@ -21,9 +21,12 @@ function Restaurang() {
         navigate("/");
         return;
       }
-      const res = await fetch(`${BASE_URL}/api/admin/orders/today`, {
-        credentials: "include",
-      });
+      const res = await fetch(
+        `${BASE_URL}/api/admin/orders/today?slug=${profile.restaurangSlug}`,
+        {
+          credentials: "include",
+        }
+      );
       if (res.status === 401) {
         navigate("/login");
         return;


### PR DESCRIPTION
## Summary
- filter `hamtaDagensOrdrar` by `restaurangSlug`
- require slug on `/api/admin/orders/today`
- send slug from admin and courier UIs when fetching orders
- test that slug filtering works

## Testing
- `npm --prefix frontend run lint`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68598954a6a4832ea9d5ba8ef3c85f83