### PR TITLE
Add SunSushi placeholder route

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -321,6 +321,15 @@ function App() {
             </div>
           }
         />
+        <Route
+          path="/sunsushi"
+          element={
+            <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
+              <h1>SunSushi Meny</h1>
+              <p>Meny kommer snart.</p>
+            </div>
+          }
+        />
       </Routes>
 
       {inloggad &&


### PR DESCRIPTION
## Summary
- add new route `/sunsushi` in the app
- link to the route from `ValjRestaurang`

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_e_685991fd6778832ea59fa323b7e63d1d