### PR TITLE
Enable SunSushi menu selection

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -51,6 +51,13 @@ function App() {
   }, [location.search]);
 
   useEffect(() => {
+    const slugPath = location.pathname.slice(1).toLowerCase();
+    if (["campino", "sunsushi"].includes(slugPath)) {
+      setRestaurangSlug(slugPath);
+    }
+  }, [location.pathname]);
+
+  useEffect(() => {
     document.body.className = tema;
     localStorage.setItem("tema", tema);
   }, [tema]);
@@ -328,7 +335,63 @@ function App() {
           element={
             <div style={{ padding: "2rem", fontFamily: "sans-serif" }}>
               <h1>SunSushi Meny</h1>
-              <p>Meny kommer snart.</p>
+              {loading && <p>Laddar meny...</p>}
+              {error && <p style={{ color: "red" }}>{error}</p>}
+              <div className="menu-container">
+                {!loading &&
+                  !error &&
+                  meny.map((ratt) => (
+                    <div
+                      key={ratt.id}
+                      className="menu-card"
+                      onClick={() => {
+                        if (!inloggad) {
+                          alert(
+                            "🔒 Du måste logga in för att kunna göra en beställning."
+                          );
+                          navigate("/login");
+                          return;
+                        }
+                        setValdRatt(ratt);
+                      }}
+                      style={{ cursor: "pointer" }}
+                    >
+                      <img
+                        src={`/bilder/${ratt.bild}`}
+                        alt={ratt.namn}
+                        className="menu-image"
+                        onError={(e) => {
+                          e.target.src = "/bilder/default.jpg";
+                        }}
+                      />
+                      <h2>{ratt.namn}</h2>
+                      <p>{ratt.beskrivning}</p>
+                      <p>
+                        <strong>{ratt.pris} kr</strong>
+                      </p>
+                    </div>
+                  ))}
+              </div>
+
+              {valdRatt && (
+                <Undermeny
+                  ratt={valdRatt}
+                  tillbehor={tillbehor}
+                  isLoggedIn={inloggad}
+                  onClose={() => setValdRatt(null)}
+                  onAddToCart={(val) => {
+                    if (redigeringsIndex !== null) {
+                      const ny = [...varukorg];
+                      ny[redigeringsIndex] = val;
+                      setVarukorg(ny);
+                      setRedigeringsIndex(null);
+                    } else {
+                      setVarukorg([...varukorg, val]);
+                    }
+                    setValdRatt(null);
+                  }}
+                />
+              )}
             </div>
           }
         />

--- a/frontend/src/ValjRestaurang.jsx
+++ b/frontend/src/ValjRestaurang.jsx
@@ -9,11 +9,13 @@ function ValjRestaurang() {
       namn: "Campino",
       bild: "/bilder/campino.png", // byt till en riktig logotyp om du har
       länk: "/campino",
+      slug: "campino",
     },
     {
       namn: "SunSushi",
       bild: "/bilder/sunsushi.png", // placeholderbild
       länk: "/sunsushi",
+      slug: "sunsushi",
     },
     // framtida: { namn: "SushiBar", bild: "...", länk: "/sushibar" }
   ];
@@ -27,7 +29,7 @@ function ValjRestaurang() {
           <button
             key={index}
             type="button"
-            onClick={() => navigate(r.länk)}
+            onClick={() => navigate(`${r.länk}?restaurang=${r.slug}`)}
             className="restaurang-kort"
           >
             <img


### PR DESCRIPTION
## Summary
- load menu based on pathname so `/campino` and `/sunsushi` work
- implement full menu for SunSushi route
- include restaurant slug when navigating from restaurant list

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c53a7d730832e8cd31637c78462db