### PR TITLE
Enhance admin slug verification

### DIFF
--- a/backend/authMiddleware.js
+++ b/backend/authMiddleware.js
@@ -29,5 +29,18 @@ function verifyRole(requiredRole) {
     });
   };
 }
-module.exports = { verifyToken, verifyRole };
+
+function verifyAdminForSlug(req, res, next) {
+  verifyToken(req, res, () => {
+    if (req.user.role !== "admin") {
+      return res.status(403).json({ error: "Otillräcklig behörighet" });
+    }
+    const slug = req.query?.slug || req.body?.slug || req.params?.slug;
+    if (slug && req.user.restaurangSlug !== slug) {
+      return res.status(403).json({ error: "Fel restaurang" });
+    }
+    next();
+  });
+}
+module.exports = { verifyToken, verifyRole, verifyAdminForSlug };
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,7 +3,7 @@ const cors = require("cors");
 const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 const cookieParser = require("cookie-parser");
-const { verifyToken, verifyRole } = require("./authMiddleware");
+const { verifyToken, verifyRole, verifyAdminForSlug } = require("./authMiddleware");
 const { body, validationResult } = require("express-validator");
 const dotenv = require("dotenv");
 const authRouter = require("./routes/auth");
@@ -116,7 +116,7 @@ app.post(
 );
 
 // ADMIN – HÄMTA ORDRAR
-app.get("/api/admin/orders/today", verifyRole("admin"), (req, res) => {
+app.get("/api/admin/orders/today", verifyAdminForSlug, (req, res) => {
   const { slug } = req.query;
   if (!slug) {
     return res.status(400).json({ message: "Slug saknas" });
@@ -130,7 +130,7 @@ app.get("/api/admin/orders/today", verifyRole("admin"), (req, res) => {
   });
 });
 
-app.get("/api/admin/orders/latest", verifyRole("admin"), (req, res) => {
+app.get("/api/admin/orders/latest", verifyAdminForSlug, (req, res) => {
   hamtaSenasteOrder((err, order) => {
     if (err) {
       console.error("Fel vid hämtning av senaste order:", err);
@@ -140,7 +140,7 @@ app.get("/api/admin/orders/latest", verifyRole("admin"), (req, res) => {
   });
 });
 
-app.patch("/api/admin/orders/:id/klart", verifyRole("admin"), (req, res) => {
+app.patch("/api/admin/orders/:id/klart", verifyAdminForSlug, (req, res) => {
   const orderId = req.params.id;
   markeraOrderSomKlar(orderId, (err) => {
     if (err) {

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -34,7 +34,7 @@ describe('API endpoints', () => {
       restaurangSlug: 'campino'
     };
 
-    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
+    const token = jwt.sign({ userId: 1, role: 'admin', restaurangSlug: 'campino' }, SECRET);
     const res = await request(app)
       .post('/api/order')
       .set('Authorization', `Bearer ${token}`)
@@ -69,7 +69,7 @@ describe('API endpoints', () => {
       restaurangSlug: 'campino'
     };
 
-    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
+    const token = jwt.sign({ userId: 1, role: 'admin', restaurangSlug: 'campino' }, SECRET);
     const res = await request(app)
       .post('/api/order')
       .set('Cookie', [`accessToken=${token}`])
@@ -80,7 +80,7 @@ describe('API endpoints', () => {
   });
 
   test('PATCH /api/admin/orders/:id/klart marks order as done', async () => {
-    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
+    const token = jwt.sign({ userId: 1, role: 'admin', restaurangSlug: 'campino' }, SECRET);
 
     const newOrder = {
       kund: {
@@ -128,7 +128,7 @@ describe('API endpoints', () => {
   });
 
   test('GET /api/admin/orders/today filters by slug', async () => {
-    const token = jwt.sign({ userId: 1, role: 'admin' }, SECRET);
+    const token = jwt.sign({ userId: 1, role: 'admin', restaurangSlug: 'campino' }, SECRET);
 
     const order1 = {
       kund: {
@@ -171,5 +171,13 @@ describe('API endpoints', () => {
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.every(o => o.restaurangSlug === 'campino')).toBe(true);
+  });
+
+  test('GET /api/admin/orders/today returns 403 for wrong slug', async () => {
+    const token = jwt.sign({ userId: 1, role: 'admin', restaurangSlug: 'campino' }, SECRET);
+    const res = await request(app)
+      .get('/api/admin/orders/today?slug=bistro')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(403);
   });
 });


### PR DESCRIPTION
## Summary
- add `verifyAdminForSlug` middleware
- use slug-based middleware in admin routes
- update backend tests for admin slug checking

## Testing
- `npm test` in `backend/`
- `npm run lint` in `frontend/`


------
https://chatgpt.com/codex/tasks/task_e_685c576a177c832e9f8ae6860c69b9f7