### PR TITLE
Remove SunSushi scraping references

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,6 @@ cd ../backend
 npm test
 ```
 
-### 12. Uppdatera SunSushi-menyn
-Kräver internetåtkomst. Kör scriptet från projektroten:
-```bash
-node backend/scrapeSunSushi.js
-```
-Filen `backend/Data/menyer/sunsushi.json` skrivs över med aktuell meny.
-
 ## 📌 Funktioner (MVP)
 
 - Visa meny med rätter & tillbehör


### PR DESCRIPTION
## Summary
- remove outdated SunSushi scraping instructions from README

## Testing
- `npm test` *(fails: ENOENT Kött.json)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687a92c01260832e831a93f3e9040b7d