### PR TITLE
Insert CSP middleware

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -28,6 +28,20 @@ const {
 
 app.use(cors(corsOptions));
 
+app.use((req, res, next) => {
+  res.setHeader(
+    "Content-Security-Policy",
+    "default-src 'self'; " +
+      "script-src 'self' https://apis.google.com https://js.stripe.com; " +
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
+      "font-src 'self' https://fonts.gstatic.com; " +
+      "img-src 'self' data: blob:; " +
+      "connect-src 'self' https://your-api.com https://*.stripe.com; " +
+      "frame-src https://js.stripe.com;"
+  );
+  next();
+});
+
 app.use(express.json());
 app.use(cookieParser());
 app.use("/api/auth", authRouter);


### PR DESCRIPTION
## Summary
- add CSP header middleware after CORS setup

## Testing
- `npm run lint` (frontend)
- `npm test` *(fails: ENOENT no such file or directory 'Data/Tillbehör/Kött.json')*


------
https://chatgpt.com/codex/tasks/task_e_687a9850f598832e875210e07617b37c