### PR TITLE
Refactor backend startup entrypoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "test": "jest",
     "start": "node startup.js",
-    "start:dev": "node server.js",
+    "start:dev": "node src/server.js",
     "payouts:run": "node backend/tasks/generatePayouts.js",
     "fix-sequences": "node fixSequence.js",
     "prepush": "npm test"

--- a/backend/server.js
+++ b/backend/server.js
@@ -926,14 +926,5 @@ app.get("/api/orders", verifyJWT, async (req, res) => {
   }
 });
 
-// Starta servern
-if (require.main === module) {
-  app.listen(PORT, () => {
-    console.log(`Servern körs på http://localhost:${PORT}`);
-    console.log(`Frontend: ${process.env.FRONTEND_ORIGIN || "http://localhost:5173"}`);
-    console.log(`Admin Panel: ${process.env.FRONTEND_ORIGIN || "http://localhost:5173"}/admin`);
-  });
-}
-
 module.exports = app;
 module.exports.corsOptions = corsOptions;

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -1,161 +1,161 @@
 // Set environment variables before loading the server
-process.env.JWT_SECRET = 'test-secret-key-for-testing-only';
-process.env.NODE_ENV = 'test';
+process.env.JWT_SECRET = "test-secret-key-for-testing-only";
+process.env.NODE_ENV = "test";
 
-const request = require('supertest');
-const jwt = require('jsonwebtoken');
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
 
 const SECRET = process.env.JWT_SECRET;
 
 const app = require("./src/app");
-const pool = require('./db');
+const pool = require("./db");
 
-describe('API endpoints', () => {
+describe("API endpoints", () => {
   afterAll(async () => {
     await pool.end();
   });
 
-  test('GET /api/meny returns a list of menu items', async () => {
-    const res = await request(app).get('/api/meny');
+  test("GET /api/meny returns a list of menu items", async () => {
+    const res = await request(app).get("/api/meny");
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBeGreaterThan(0);
   });
 
-  test('POST /api/order stores an order successfully', async () => {
+  test("POST /api/order stores an order successfully", async () => {
     const newOrder = {
-      namn: 'Test Testsson',
-      telefon: '123456789',
-      adress: 'Testgatan 1',
+      namn: "Test Testsson",
+      telefon: "123456789",
+      adress: "Testgatan 1",
       email: `test_${Date.now()}@example.com`,
       order: [
-        { id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }
+        { id: 1, namn: "MARGARITA", antal: 1, pris: 125, total: 125 }
       ],
-      restaurant_slug: 'campino'
+      restaurant_slug: "campino"
     };
 
-    const token = jwt.sign({ userId: 1, role: 'admin', restaurant_slug: 'campino' }, SECRET);
+    const token = jwt.sign({ userId: 1, role: "admin", restaurant_slug: "campino" }, SECRET);
     const res = await request(app)
-      .post('/api/order')
-      .set('Authorization', `Bearer ${token}`)
+      .post("/api/order")
+      .set("Authorization", `Bearer ${token}`)
       .send(newOrder);
     expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveProperty('orderId');
+    expect(res.body).toHaveProperty("orderId");
 
-    const inserted = await pool.query('SELECT * FROM orders WHERE id = $1', [res.body.orderId]);
+    const inserted = await pool.query("SELECT * FROM orders WHERE id = $1", [res.body.orderId]);
 
     expect(inserted.rows.length).toBeGreaterThan(0);
     expect(inserted.rows[0].customer_name).toBe(newOrder.namn);
     expect(inserted.rows[0].restaurant_slug).toBe(newOrder.restaurant_slug);
   });
 
-  test('POST /api/order works with cookie token', async () => {
+  test("POST /api/order works with cookie token", async () => {
     const newOrder = {
-      namn: 'Cookie Testsson',
-      telefon: '111222333',
-      adress: 'Cookiegatan 3',
+      namn: "Cookie Testsson",
+      telefon: "111222333",
+      adress: "Cookiegatan 3",
       email: `cookie_${Date.now()}@example.com`,
       order: [
-        { id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }
+        { id: 1, namn: "MARGARITA", antal: 1, pris: 125, total: 125 }
       ],
-      restaurant_slug: 'campino'
+      restaurant_slug: "campino"
     };
 
-    const token = jwt.sign({ userId: 1, role: 'admin', restaurant_slug: 'campino' }, SECRET);
+    const token = jwt.sign({ userId: 1, role: "admin", restaurant_slug: "campino" }, SECRET);
     const res = await request(app)
-      .post('/api/order')
-      .set('Cookie', [`accessToken=${token}`])
+      .post("/api/order")
+      .set("Cookie", [`accessToken=${token}`])
       .send(newOrder);
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveProperty('orderId');
+    expect(res.body).toHaveProperty("orderId");
   });
 
-  test('PUT /api/admin/orders/:id/klart marks order as done', async () => {
-    const token = jwt.sign({ userId: 1, role: 'admin', restaurant_slug: 'campino' }, SECRET);
+  test("PUT /api/admin/orders/:id/klart marks order as done", async () => {
+    const token = jwt.sign({ userId: 1, role: "admin", restaurant_slug: "campino" }, SECRET);
 
     const newOrder = {
-      namn: 'Patch Test',
-      telefon: '987654321',
-      adress: 'Patchgatan 2',
+      namn: "Patch Test",
+      telefon: "987654321",
+      adress: "Patchgatan 2",
       email: `patch_${Date.now()}@example.com`,
       order: [
-        { id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }
+        { id: 1, namn: "MARGARITA", antal: 1, pris: 125, total: 125 }
       ],
-      restaurant_slug: 'campino'
+      restaurant_slug: "campino"
     };
 
     const createRes = await request(app)
-      .post('/api/order')
-      .set('Authorization', `Bearer ${token}`)
+      .post("/api/order")
+      .set("Authorization", `Bearer ${token}`)
       .send(newOrder);
 
     const orderId = createRes.body.orderId;
 
     const patchRes = await request(app)
       .put(`/api/admin/orders/${orderId}/klart`)
-      .set('Authorization', `Bearer ${token}`);
+      .set("Authorization", `Bearer ${token}`);
 
     expect(patchRes.statusCode).toBe(200);
-    expect(patchRes.body).toHaveProperty('message', 'Order markerad som klar');
+    expect(patchRes.body).toHaveProperty("message", "Order markerad som klar");
 
-    const updated = await pool.query('SELECT status FROM orders WHERE id = $1', [orderId]);
+    const updated = await pool.query("SELECT status FROM orders WHERE id = $1", [orderId]);
 
-    expect(updated.rows[0].status).toBe('delivered');
+    expect(updated.rows[0].status).toBe("delivered");
   });
 
-  test('POST /api/order returns 401 without token', async () => {
+  test("POST /api/order returns 401 without token", async () => {
     const res = await request(app)
-      .post('/api/order')
+      .post("/api/order")
       .send({});
     expect(res.statusCode).toBe(401);
   });
 
-  test('GET /api/admin/orders/today filters by slug', async () => {
-    const token = jwt.sign({ userId: 1, role: 'admin', restaurant_slug: 'campino' }, SECRET);
+  test("GET /api/admin/orders/today filters by slug", async () => {
+    const token = jwt.sign({ userId: 1, role: "admin", restaurant_slug: "campino" }, SECRET);
 
     const order1 = {
-      namn: 'Slug Test1',
-      telefon: '000',
-      adress: 'A',
+      namn: "Slug Test1",
+      telefon: "000",
+      adress: "A",
       email: `slug1_${Date.now()}@example.com`,
-      order: [{ id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }],
-      restaurant_slug: 'campino'
+      order: [{ id: 1, namn: "MARGARITA", antal: 1, pris: 125, total: 125 }],
+      restaurant_slug: "campino"
     };
 
     const order2 = {
-      namn: 'Slug Test2',
-      telefon: '111',
-      adress: 'B',
+      namn: "Slug Test2",
+      telefon: "111",
+      adress: "B",
       email: `slug2_${Date.now()}@example.com`,
-      order: [{ id: 1, namn: 'MARGARITA', antal: 1, pris: 125, total: 125 }],
-      restaurant_slug: 'bistro'
+      order: [{ id: 1, namn: "MARGARITA", antal: 1, pris: 125, total: 125 }],
+      restaurant_slug: "bistro"
     };
 
     await request(app)
-      .post('/api/order')
-      .set('Authorization', `Bearer ${token}`)
+      .post("/api/order")
+      .set("Authorization", `Bearer ${token}`)
       .send(order1);
 
     await request(app)
-      .post('/api/order')
-      .set('Authorization', `Bearer ${token}`)
+      .post("/api/order")
+      .set("Authorization", `Bearer ${token}`)
       .send(order2);
 
     const res = await request(app)
-      .get('/api/admin/orders/today?slug=campino')
-      .set('Authorization', `Bearer ${token}`);
+      .get("/api/admin/orders/today?slug=campino")
+      .set("Authorization", `Bearer ${token}`);
 
     expect(res.statusCode).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body.every(o => o.restaurant_slug === 'campino')).toBe(true);
+    expect(res.body.every(o => o.restaurant_slug === "campino")).toBe(true);
   });
 
-  test('GET /api/admin/orders/today returns 403 for wrong slug', async () => {
-    const token = jwt.sign({ userId: 1, role: 'admin', restaurant_slug: 'campino' }, SECRET);
+  test("GET /api/admin/orders/today returns 403 for wrong slug", async () => {
+    const token = jwt.sign({ userId: 1, role: "admin", restaurant_slug: "campino" }, SECRET);
     const res = await request(app)
-      .get('/api/admin/orders/today?slug=bistro')
-      .set('Authorization', `Bearer ${token}`);
+      .get("/api/admin/orders/today?slug=bistro")
+      .set("Authorization", `Bearer ${token}`);
     expect(res.statusCode).toBe(403);
   });
 });

--- a/backend/server.test.js
+++ b/backend/server.test.js
@@ -7,7 +7,7 @@ const jwt = require('jsonwebtoken');
 
 const SECRET = process.env.JWT_SECRET;
 
-const app = require('./server');
+const app = require("./src/app");
 const pool = require('./db');
 
 describe('API endpoints', () => {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,14 +1,14 @@
-const express = require('express');
-const cookieParser = require('cookie-parser');
-const cors = require('./config/cors');
-const { securityHeaders } = require('./config/security');
-const errorHandler = require('./middleware/errorHandler');
+const express = require("express");
+const cookieParser = require("cookie-parser");
+const cors = require("./config/cors");
+const { securityHeaders } = require("./config/security");
+const errorHandler = require("./middleware/errorHandler");
 
 // Import routes
-const authRoutes = require('./routes/auth_new');
-const orderRoutes = require('./routes/orders');
-const menuRoutes = require('./routes/menu_simple');
-const legacyApp = require('../server');
+const authRoutes = require("./routes/auth_new");
+const orderRoutes = require("./routes/orders");
+const menuRoutes = require("./routes/menu_simple");
+const legacyApp = require("../server");
 
 /**
  * Express Application
@@ -23,44 +23,48 @@ app.use(securityHeaders);
 app.use(cors);
 
 // Body parsing middleware
-app.use(express.json({ limit: '10mb' }));
-app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 
 // Cookie parser
 app.use(cookieParser());
 
 // Health check endpoint
-app.get('/health', (req, res) => {
+app.get("/health", (req, res) => {
   res.json({
     success: true,
-    message: 'Server is running',
+    message: "Server is running",
     timestamp: new Date().toISOString(),
     uptime: process.uptime()
   });
 });
 
 // API routes
-app.use('/api/auth', authRoutes);
-app.use('/api/order', orderRoutes);
-app.use('/api/menu', menuRoutes);
+app.use("/api/auth", authRoutes);
+app.use("/api/order", orderRoutes);
+app.use("/api/menu", menuRoutes);
 
 // Legacy application routes for backward compatibility
 app.use(legacyApp);
 
 // Legacy profile endpoint for backward compatibility
-app.get('/api/profile', require('./middleware/authMiddleware').verifyJWT, (req, res) => {
-  res.json({
-    success: true,
-    data: {
-      id: req.user.id,
-      email: req.user.email,
-      namn: req.user.namn || '',
-      telefon: req.user.telefon || '',
-      adress: req.user.adress || '',
-      role: req.user.role
-    }
-  });
-});
+app.get(
+  "/api/profile",
+  require("./middleware/authMiddleware").verifyJWT,
+  (req, res) => {
+    res.json({
+      success: true,
+      data: {
+        id: req.user.id,
+        email: req.user.email,
+        namn: req.user.namn || "",
+        telefon: req.user.telefon || "",
+        adress: req.user.adress || "",
+        role: req.user.role
+      }
+    });
+  }
+);
 
 // 404 handler
 app.use((req, res) => {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -8,6 +8,7 @@ const errorHandler = require('./middleware/errorHandler');
 const authRoutes = require('./routes/auth_new');
 const orderRoutes = require('./routes/orders');
 const menuRoutes = require('./routes/menu_simple');
+const legacyApp = require('../server');
 
 /**
  * Express Application
@@ -43,6 +44,9 @@ app.use('/api/auth', authRoutes);
 app.use('/api/order', orderRoutes);
 app.use('/api/menu', menuRoutes);
 
+// Legacy application routes for backward compatibility
+app.use(legacyApp);
+
 // Legacy profile endpoint for backward compatibility
 app.get('/api/profile', require('./middleware/authMiddleware').verifyJWT, (req, res) => {
   res.json({
@@ -59,10 +63,10 @@ app.get('/api/profile', require('./middleware/authMiddleware').verifyJWT, (req, 
 });
 
 // 404 handler
-app.use('*', (req, res) => {
+app.use((req, res) => {
   res.status(404).json({
     success: false,
-    message: 'Endpoint not found'
+    message: "Endpoint not found"
   });
 });
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,17 @@
+require("dotenv").config();
+
+const app = require("./app");
+
+const PORT = process.env.PORT || 3001;
+
+const server = app.listen(PORT, () => {
+  if (process.env.NODE_ENV !== "test") {
+    console.log(`Servern körs på http://localhost:${PORT}`);
+    console.log(`Frontend: ${process.env.FRONTEND_ORIGIN || "http://localhost:5173"}`);
+    console.log(
+      `Admin Panel: ${(process.env.FRONTEND_ORIGIN || "http://localhost:5173")}/admin`
+    );
+  }
+});
+
+module.exports = server;

--- a/backend/startup.js
+++ b/backend/startup.js
@@ -1,22 +1,22 @@
-const { Pool } = require('pg');
-require('dotenv').config();
-const { createTables } = require('./createTables');
-const { autoFixSequences } = require('./autoFixSequences');
+const { Pool } = require("pg");
+require("dotenv").config();
+const { createTables } = require("./createTables");
+const { autoFixSequences } = require("./autoFixSequences");
 
 // Konfiguration för anslutning till PostgreSQL
 const dbConfig = {
-  user: process.env.DB_USER || process.env.PGUSER || 'postgres',
-  host: process.env.DB_HOST || process.env.PGHOST || 'localhost',
-  password: process.env.DB_PASSWORD || process.env.PGPASSWORD || 'asha',
+  user: process.env.DB_USER || process.env.PGUSER || "postgres",
+  host: process.env.DB_HOST || process.env.PGHOST || "localhost",
+  password: process.env.DB_PASSWORD || process.env.PGPASSWORD || "asha",
   port: parseInt(process.env.DB_PORT || process.env.PGPORT) || 5432,
 };
 
-const dbName = process.env.DB_NAME || process.env.PGDATABASE || 'annos';
+const dbName = process.env.DB_NAME || process.env.PGDATABASE || "annos";
 
 // Pool för anslutning till PostgreSQL (utan specifik databas först)
 const adminPool = new Pool({
   ...dbConfig,
-  database: 'postgres' // Anslut till default postgres-databas först
+  database: "postgres" // Anslut till default postgres-databas först
 });
 
 /**
@@ -30,7 +30,7 @@ async function ensureDatabaseExists() {
     
     // Kontrollera om databasen existerar
     const result = await adminClient.query(
-      'SELECT 1 FROM pg_database WHERE datname = $1',
+      "SELECT 1 FROM pg_database WHERE datname = $1",
       [dbName]
     );
     
@@ -59,49 +59,49 @@ async function ensureDatabaseExists() {
  */
 async function startupSequence() {
   try {
-    console.log('🚀 Startar startup sequence...\n');
+    console.log("🚀 Startar startup sequence...\n");
     
     // 1. INFRASTRUCTURE SETUP
-    console.log('📋 Steg 1: Infrastructure Setup');
-    console.log('   - Kontrollerar PostgreSQL-anslutning...');
+    console.log("📋 Steg 1: Infrastructure Setup");
+    console.log("   - Kontrollerar PostgreSQL-anslutning...");
     
     // Testa anslutning till PostgreSQL
     const adminClient = await adminPool.connect();
-    await adminClient.query('SELECT 1');
+    await adminClient.query("SELECT 1");
     adminClient.release();
-    console.log('   ✅ PostgreSQL-anslutning OK');
+    console.log("   ✅ PostgreSQL-anslutning OK");
     
     // Skapa databas om den inte existerar
     await ensureDatabaseExists();
     
     // Testa anslutning till applikationsdatabas
-    console.log('   - Kontrollerar anslutning till applikationsdatabas...');
-    const appPool = require('./db'); // Använd samma pool som resten av applikationen
+    console.log("   - Kontrollerar anslutning till applikationsdatabas...");
+    const appPool = require("./db"); // Använd samma pool som resten av applikationen
     const appClient = await appPool.connect();
-    await appClient.query('SELECT 1');
+    await appClient.query("SELECT 1");
     appClient.release();
-    console.log('   ✅ Applikationsdatabas-anslutning OK\n');
+    console.log("   ✅ Applikationsdatabas-anslutning OK\n");
     
     // 2. DATA MIGRATION
-    console.log('📋 Steg 2: Data Migration');
-    console.log('   - Skapar tabeller och sequences...');
+    console.log("📋 Steg 2: Data Migration");
+    console.log("   - Skapar tabeller och sequences...");
     
     await createTables();
-    console.log('   ✅ Tabeller och sequences skapade\n');
+    console.log("   ✅ Tabeller och sequences skapade\n");
     
     // 3. MAINTENANCE TASKS
-    console.log('📋 Steg 3: Maintenance Tasks');
-    console.log('   - Synkroniserar sequences...');
+    console.log("📋 Steg 3: Maintenance Tasks");
+    console.log("   - Synkroniserar sequences...");
     
     await autoFixSequences();
-    console.log('   ✅ Sequences synkroniserade\n');
+    console.log("   ✅ Sequences synkroniserade\n");
     
     // Stäng admin pool nu när vi inte behöver den längre
     await adminPool.end();
     
     // 4. APPLICATION STARTUP
-    console.log('📋 Steg 4: Application Startup');
-    console.log('   - Startar Express server...');
+    console.log("📋 Steg 4: Application Startup");
+    console.log("   - Startar Express server...");
     
     // Importera och starta server
     const app = require("./src/app");
@@ -111,11 +111,11 @@ async function startupSequence() {
       console.log(`   ✅ Servern körs på http://localhost:${PORT}`);
       console.log(`   ✅ Frontend: ${process.env.FRONTEND_ORIGIN || "http://localhost:5173"}`);
       console.log(`   ✅ Admin Panel: ${process.env.FRONTEND_ORIGIN || "http://localhost:5173"}/admin`);
-      console.log('\n🎉 Startup sequence slutförd!');
+      console.log("\n🎉 Startup sequence slutförd!");
     });
     
   } catch (error) {
-    console.error('💥 Startup sequence misslyckades:', error);
+    console.error("💥 Startup sequence misslyckades:", error);
     process.exit(1);
   }
 }

--- a/backend/startup.js
+++ b/backend/startup.js
@@ -104,9 +104,9 @@ async function startupSequence() {
     console.log('   - Startar Express server...');
     
     // Importera och starta server
-    const app = require('./server');
-    const PORT = process.env.PORT || 3000;
-    
+    const app = require("./src/app");
+    const PORT = process.env.PORT || 3001;
+
     app.listen(PORT, () => {
       console.log(`   ✅ Servern körs på http://localhost:${PORT}`);
       console.log(`   ✅ Frontend: ${process.env.FRONTEND_ORIGIN || "http://localhost:5173"}`);

--- a/frontend/test_new_endpoints.js
+++ b/frontend/test_new_endpoints.js
@@ -1,59 +1,62 @@
 /**
  * Test script för att verifiera att de nya meny-endpoints fungerar
  */
-import { MenuService } from './src/services/menu/menuService.js';
+import { MenuService } from "./src/services/menu/menuService.js";
 
 async function testNewEndpoints() {
-  console.log('🧪 Testar nya meny-endpoints...\n');
+  console.log("🧪 Testar nya meny-endpoints...\n");
 
   try {
     // Test 1: Hämta restauranger
-    console.log('1. Testar fetchRestaurants...');
+    console.log("1. Testar fetchRestaurants...");
     const restaurants = await MenuService.fetchRestaurants();
-    console.log('✅ Restauranger:', restaurants.length, 'st');
-    console.log('   Data:', restaurants.map(r => r.name).join(', '));
-    console.log('');
+    console.log("✅ Restauranger:", restaurants.length, "st");
+    console.log("   Data:", restaurants.map(r => r.name).join(", "));
+    console.log("");
 
     // Test 2: Hämta meny för Campino
-    console.log('2. Testar fetchMenu för Campino...');
-    const menu = await MenuService.fetchMenu('campino');
-    console.log('✅ Meny:', menu.length, 'items');
-    console.log('   Första item:', menu[0]?.namn || 'Ingen data');
-    console.log('');
+    console.log("2. Testar fetchMenu för Campino...");
+    const menu = await MenuService.fetchMenu("campino");
+    console.log("✅ Meny:", menu.length, "items");
+    console.log("   Första item:", menu[0]?.namn || "Ingen data");
+    console.log("");
 
     // Test 3: Hämta tillbehör för Campino
-    console.log('3. Testar fetchAccessories för Campino...');
-    const accessories = await MenuService.fetchAccessories('campino');
-    console.log('✅ Tillbehör:', accessories.length, 'st');
-    console.log('   Första tillbehör:', accessories[0]?.namn || 'Ingen data');
-    console.log('');
+    console.log("3. Testar fetchAccessories för Campino...");
+    const accessories = await MenuService.fetchAccessories("campino");
+    console.log("✅ Tillbehör:", accessories.length, "st");
+    console.log("   Första tillbehör:", accessories[0]?.namn || "Ingen data");
+    console.log("");
 
     // Test 4: Hämta kategorier för Campino
-    console.log('4. Testar fetchCategories för Campino...');
-    const categories = await MenuService.fetchCategories('campino');
-    console.log('✅ Kategorier:', categories.length, 'st');
-    console.log('   Kategorier:', categories.slice(0, 3).join(', '), '...');
-    console.log('');
+    console.log("4. Testar fetchCategories för Campino...");
+    const categories = await MenuService.fetchCategories("campino");
+    console.log("✅ Kategorier:", categories.length, "st");
+    console.log("   Kategorier:", categories.slice(0, 3).join(", "), "...");
+    console.log("");
 
     // Test 5: Sök i meny
-    console.log('5. Testar searchMenu för "pizza"...');
-    const searchResults = await MenuService.searchMenu('campino', 'pizza');
-    console.log('✅ Sökresultat:', searchResults.length, 'items');
-    console.log('   Första resultat:', searchResults[0]?.namn || 'Ingen data');
-    console.log('');
+    console.log("5. Testar searchMenu för \"pizza\"...");
+    const searchResults = await MenuService.searchMenu("campino", "pizza");
+    console.log("✅ Sökresultat:", searchResults.length, "items");
+    console.log("   Första resultat:", searchResults[0]?.namn || "Ingen data");
+    console.log("");
 
     // Test 6: Hämta grupperade tillbehör
-    console.log('6. Testar fetchGroupedAccessories för Campino...');
-    const groupedAccessories = await MenuService.fetchGroupedAccessories('campino');
-    console.log('✅ Grupperade tillbehör:', Object.keys(groupedAccessories).length, 'grupper');
-    console.log('   Grupper:', Object.keys(groupedAccessories).join(', '));
-    console.log('');
+    console.log("6. Testar fetchGroupedAccessories för Campino...");
+    const groupedAccessories = await MenuService.fetchGroupedAccessories("campino");
+    console.log(
+      "✅ Grupperade tillbehör:",
+      Object.keys(groupedAccessories).length,
+      "grupper"
+    );
+    console.log("   Grupper:", Object.keys(groupedAccessories).join(", "));
+    console.log("");
 
-    console.log('🎉 Alla tester passerade! De nya endpoints fungerar korrekt.');
-
+    console.log("🎉 Alla tester passerade! De nya endpoints fungerar korrekt.");
   } catch (error) {
-    console.error('❌ Test misslyckades:', error.message);
-    console.error('   Detaljer:', error);
+    console.error("❌ Test misslyckades:", error.message);
+    console.error("   Detaljer:", error);
   }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated `src/server.js` entrypoint that loads the modular Express app and exports the listener
- update the startup sequence and npm scripts to bootstrap `src/app` before listening
- keep the legacy server as a pure module and mount it inside the modular app for backward compatibility

## Testing
- `npm start` *(fails: PostgreSQL connection refused in this environment)*
- `npm run start:dev`
- `npm test` *(fails: PostgreSQL connection refused during legacy order endpoints)*

------
https://chatgpt.com/codex/tasks/task_e_68e19b62d9d8832ebbfd703ec6731312