### PR TITLE
docs: update express entrypoint references

### DIFF
--- a/FILES_OVERVIEW.md
+++ b/FILES_OVERVIEW.md
@@ -31,11 +31,11 @@
 | **package-lock.json** | Låsta versionsnummer för Node.js-beroenden |
 | **package.json** | Node.js-beroenden och skript |
 | **POSTGRESQL_MIGRATION_SUMMARY.md** | Sammanfattning av PostgreSQL-migrering |
-| **server.js** | Huvudserverfil med Express.js-applikation, API-routes och middleware |
-| **Legacy/backend/server_end.js** | Alternativ serverfil (legacy/backup) |
-| **Legacy/backend/server_fixed.js** | Ytterligare servervariant (legacy/backup) |
+| **src/app.js** | Aktiv Express-applikation med middleware och API-rutter |
+| **src/server.js** | Serverstart som importerar `src/app.js` |
 | **server.test.js** | Testfiler för serverfunktionalitet |
 | **skapaAdmin.js** | Skript för att skapa administratörskonton |
+| **legacy/** | Temporära backend-hjälpverktyg som väntar på migrering |
 
 ### Backend - Data och menyhantering
 
@@ -78,6 +78,13 @@
 |-----|------------------|
 | **legacy/initDB.js** | Legacy databasinitialisering |
 | **legacy/README.md** | Dokumentation för legacy-komponenter |
+
+## Legacy (`Legacy/`)
+
+| Fil / Katalog | Syfte / funktion |
+|---------------|------------------|
+| **Legacy/backend/** | Arkiverade Express-servrar (inklusive tidigare `backend/server.js`-implementationen och varianter) |
+| **Legacy/frontend/** | Arkiverade frontend-tjänster, hooks och komponenter |
 
 ## Frontend (`frontend/`)
 
@@ -205,7 +212,7 @@
 
 | Filtyp | Roll | Exempel |
 |--------|------|---------|
-| **.js** | Node.js/Express server-filer | `server.js`, `authMiddleware.js` |
+| **.js** | Node.js/Express server-filer | `src/server.js`, `authMiddleware.js` |
 | **.jsx** | React-komponenter | `App.jsx`, `Login.jsx` |
 | **.json** | Konfigurations- och datafiler | `package.json`, `campino.json` |
 | **.css** | Stilar och tema | `index.css`, `App.css` |

--- a/README.md
+++ b/README.md
@@ -58,12 +58,16 @@ annos/
 │   │   └── utils/             → Hjälpfunktioner
 ├── backend/                    → Express API (REORGANISERAD)
 │   ├── src/                   → Ny organiserad struktur
-│   │   ├── config/            → Konfiguration
-│   │   ├── controllers/       → API-kontrollrar
-│   │   ├── middleware/        → Middleware
-│   │   ├── routes/            → API-rutter
-│   │   └── services/          → Affärslogik
-│   └── server.js              → Huvudserver (med nya endpoints)
+│   │   ├── app.js            → Aktiva Express-applikationen (middleware & routes)
+│   │   ├── server.js         → Modern serverstart som mountar `src/app.js`
+│   │   ├── config/           → Konfiguration
+│   │   ├── controllers/      → API-kontrollrar
+│   │   ├── middleware/       → Middleware
+│   │   ├── routes/           → API-rutter
+│   │   └── services/         → Affärslogik
+│   ├── startup.js            → Produktionsstart (kör full SoC-sekvens)
+│   └── legacy/               → Backend-specifika hjälpmedel som ännu inte migrerats
+├── Legacy/                     → Arkiverade backend/frontend-implementationer (tidigare `backend/server.js` m.fl.)
 ├── docs/                      → Dokumentation
 │   ├── database.md            → Databasstruktur
 │   ├── functions.md           → Systemfunktioner
@@ -72,6 +76,8 @@ annos/
 │   └── payments.md            → Betalningsarkitektur
 └── backend/exports/           → Månadsvisa payout-filer
 ```
+
+> **Notera:** Den aktiva Express-stackens kärna finns i `backend/src/app.js` (Express-applikationen) och `backend/src/server.js` (HTTP-start). Legacyvarianten som tidigare låg i `backend/server.js` är arkiverad under `Legacy/backend/` för referens.
 
 ## ⚡ Snabbstart
 
@@ -235,8 +241,9 @@ node backend/tasks/generatePayouts.js --from=2024-01-01 --to=2024-01-31
 - **Uppdaterad för nya API**: Frontend använder nu nya meny-endpoints
 
 ### ✅ Backend-reorganisation (PÅBÖRJAD)
-- **Ny mappstruktur**: `src/config/`, `src/controllers/`, `src/middleware/`, `src/routes/`, `src/services/`
-- **Nya meny-endpoints**: Integrerade i `server.js` för stegvis migration
+- **Ny mappstruktur**: `src/app.js`, `src/server.js` samt `src/config/`, `src/controllers/`, `src/middleware/`, `src/routes/`, `src/services/`
+- **Nya meny-endpoints**: Körs via `src/app.js` och mountas av `src/server.js`
+- **Legacy**: Tidigare `backend/server.js` och relaterade versioner är arkiverade i `Legacy/backend/`
 - **Miljövariabler fixade**: `.env` med korrekt PostgreSQL-lösenord
 
 ### ✅ Integration (VERIFIERAD)

--- a/backend/POSTGRESQL_MIGRATION_SUMMARY.md
+++ b/backend/POSTGRESQL_MIGRATION_SUMMARY.md
@@ -241,7 +241,7 @@ npm test
 ## ✅ All Endpoints Converted
 
 - ✅ `/api/register` - User registration
-- ✅ `/api/login` - User login (in server.js)
+- ✅ `/api/login` - User login (via `src/app.js` och `src/routes/auth_new.js`)
 - ✅ `/api/order` - Order creation
 - ✅ `/api/profile` - User profile retrieval
 - ✅ `/api/my-orders` - User's orders

--- a/backend/STARTUP_GUIDE.md
+++ b/backend/STARTUP_GUIDE.md
@@ -77,8 +77,8 @@ npm start  # Använder startup.js med full sequence
 
 ### **Development (snabb startup):**
 ```bash
-cd backend  
-npm run start:dev  # Använder server.js direkt
+cd backend
+npm run start:dev  # Kör src/server.js direkt (förutsätter färdig databas)
 ```
 
 ### **Manuell sequence-fix:**
@@ -95,7 +95,7 @@ npm run fix-sequences
 - Sequence-synkronisering
 - Server startup
 
-### **server.js (Development)**
+### **src/server.js (Development)**
 - Direkt server startup
 - Förutsätter att databas finns
 - Snabbare för utveckling
@@ -154,7 +154,7 @@ npm start  # För production
 
 ### **Undvik:**
 ```bash
-node server.js  # Hoppar över startup sequence
+node src/server.js  # Hoppar över startup sequence (kör utan SoC-säkerhetskontroller)
 ```
 
 ### **För development:**


### PR DESCRIPTION
## Summary
- document the new Express entrypoints in `backend/src/app.js` and `backend/src/server.js`
- refresh startup and migration guides to point at the updated scripts
- update the file inventory to describe archived assets under `Legacy/`

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e1af0751b8832ead628eb08db465c8