### PR TITLE
Restore login page direct API flow

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -59,16 +59,22 @@ class AuthController {
    */
   static async login(req, res, next) {
     try {
-      const { email, password } = req.body;
+      const { email, password, losenord } = req.body;
+      const submittedPassword =
+        typeof password === 'string' && password.trim().length > 0
+          ? password
+          : typeof losenord === 'string'
+            ? losenord
+            : '';
 
-      if (!email || !password) {
+      if (!email || !submittedPassword) {
         return res.status(400).json({
           success: false,
           message: 'Email and password are required'
         });
       }
 
-      const result = await AuthService.login(email, password);
+      const result = await AuthService.login(email, submittedPassword);
 
       // Set HTTP-only cookie
       res.cookie('token', result.token, {

--- a/backend/src/routes/auth_new.js
+++ b/backend/src/routes/auth_new.js
@@ -20,7 +20,18 @@ const registerValidation = [
 
 const loginValidation = [
   body('email').isEmail().normalizeEmail(),
-  body('password').notEmpty()
+  body('password').custom((value, { req }) => {
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return true;
+    }
+
+    if (typeof req.body.losenord === 'string' && req.body.losenord.trim().length > 0) {
+      req.body.password = req.body.losenord;
+      return true;
+    }
+
+    throw new Error('Password is required');
+  })
 ];
 
 const updateProfileValidation = [


### PR DESCRIPTION
## Summary
- revert the login page to its direct fetch implementation while normalizing auth responses so both legacy and `{ success, data }` payloads work
- update the auth service login helper to accept either `password` or `lösenord`, normalize the returned user profile, and persist it with cross-tab sync

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f785221c832e80db2b904bf5c9f5